### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -112,7 +112,7 @@ We are always looking for additional board members to evangelise OWASP and its m
 
 ## OWASP Statement on Participation
 
-The Open Web Application Security Project (OWASP) - managed by the non-profit OWASP Foundation - works to improve the security of software. All of our projects, tools, documents, forums, and chapters are free and open to anyone interested in improving application security. 
+The Open Worldwide Application Security Project (OWASP) - managed by the non-profit OWASP Foundation - works to improve the security of software. All of our projects, tools, documents, forums, and chapters are free and open to anyone interested in improving application security. 
 
 Chapters are led by local leaders in accordance with the [Chapter Policy](https://owasp.org/www-policy/). Financial contributions should only be made online using the authorised online donation button. To be a SPEAKER at ANY OWASP Chapter in the world simply review the [speaker agreement](https://owasp.org/www-policy/) and then contact the local chapter leader with details of what OWASP Project, independent research, or related software security topic you would like to present.
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)